### PR TITLE
track outgoing server events by event case

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,8 @@ lazy val server = project
     "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
     "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test,
     "com.typesafe.akka" %% "akka-slf4j" % "2.5.14",
+    "com.typesafe.akka" %% "akka-http-spray-json" % "10.1.4",
+    "io.dropwizard.metrics" % "metrics-core" % "4.0.3",
     "com.google.guava" % "guava" % "25.1-jre",
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "org.slf4j" % "slf4j-api" % "1.7.25",

--- a/server/src/main/scala/com/github/jpringle/royale/server/SnakeRoyaleServer.scala
+++ b/server/src/main/scala/com/github/jpringle/royale/server/SnakeRoyaleServer.scala
@@ -9,23 +9,26 @@ import akka.event.{Logging, LoggingAdapter}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model.ws.{BinaryMessage, Message}
-import akka.http.scaladsl.model.{HttpRequest, RemoteAddress}
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, RemoteAddress, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.RouteResult.{Complete, Rejected}
 import akka.http.scaladsl.server.directives.{DebuggingDirectives, LogEntry, LoggingMagnet}
 import akka.stream.scaladsl.{BroadcastHub, Flow, Keep, MergeHub, Sink, Source}
 import akka.stream.{ActorMaterializer, Materializer}
-import akka.util.ByteString
+import akka.pattern.ask
+import akka.util.{ByteString, Timeout}
 import com.github.jpringle.royale.common.SnakeProto.{ClientEvent, JoinResponse, JoinSuccess, ServerEvent}
 import com.github.jpringle.royale.server.Protocol.{AtomicUpdate, ClientEventWithId}
 import com.github.jpringle.royale.server.graphstage.{CurrentStateStage, PendingEventStage}
+import com.github.jpringle.royale.server.stats._
 import com.google.common.util.concurrent.AbstractService
 
+import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
-class SnakeRoyaleServer(port: Int, contentRoot: String)(implicit val system: ActorSystem, m: ActorMaterializer) extends AbstractService {
+class SnakeRoyaleServer(port: Int, contentRoot: String)(implicit val system: ActorSystem, m: ActorMaterializer) extends AbstractService with StatJsonSupport {
   private var binding: ServerBinding = _
   private val log = org.slf4j.LoggerFactory.getLogger(getClass.getName)
   private val idGen = new AtomicInteger(1)
@@ -33,6 +36,9 @@ class SnakeRoyaleServer(port: Int, contentRoot: String)(implicit val system: Act
   private val broadcastHub = BroadcastHub.sink[ServerEvent](bufferSize = 256)
   private val (eventSink, eventSource) = mergeHub.preMaterialize()
   private val (broadcastSource, broadcastSink) = broadcastHub.preMaterialize()
+
+  private val outgoingMessageMonitor = system.actorOf(OutgoingMessageMonitor.props)
+  private val outgoingMessageSink = Sink.actorRef(outgoingMessageMonitor, akka.NotUsed)
 
   // drain events when there are no subscribers
   broadcastSource.runWith(Sink.ignore)
@@ -46,12 +52,25 @@ class SnakeRoyaleServer(port: Int, contentRoot: String)(implicit val system: Act
     .via(new CurrentStateStage(width = 128, height = 72))
     .runWith(broadcastSink)
 
-  def toStrict(message: Message): ByteString = message match {
+  private def toStrict(message: Message): ByteString = message match {
     case BinaryMessage.Strict(data) => data
     case BinaryMessage.Streamed(dataStream) =>
       dataStream.runWith(Sink.cancelled)
       throw new IllegalArgumentException("Only strict binary messages are supported")
     case _ => throw new IllegalArgumentException("Only strict binary messages are supported")
+  }
+
+  private def statRoute: Route = {
+    implicit val timeout: Timeout = Timeout(3.seconds)
+    implicit val ec: ExecutionContextExecutor = system.dispatcher
+    val fut = (outgoingMessageMonitor ? OutgoingMessageStatRequest).mapTo[OutgoingMessageStats]
+    onComplete(fut) {
+      case Success(stats) => complete(stats)
+      case Failure(t) =>
+        val st = Logging.stackTraceFor(t)
+        log.warn(s"Exception thrown attempting to handle a stat request - $st")
+        complete(HttpResponse(StatusCodes.InternalServerError))
+    }
   }
 
   def flow: Flow[Message, Message, NotUsed] = {
@@ -68,6 +87,7 @@ class SnakeRoyaleServer(port: Int, contentRoot: String)(implicit val system: Act
       .map { event => ClientEventWithId(playerId, event) }
       .to(eventSink)
     val source = joinResponseSource.concat(broadcastSource)
+      .alsoTo(outgoingMessageSink)
       .map { event => BinaryMessage.Strict(ByteString.fromArray(event.toByteArray)) }
 
     Flow.fromSinkAndSource(sink, source).backpressureTimeout(1.second)
@@ -77,9 +97,12 @@ class SnakeRoyaleServer(port: Int, contentRoot: String)(implicit val system: Act
     complete("pong!")
   } ~ path("ws") {
     handleWebSocketMessages(flow)
-  } ~ path("" ~ PathEnd) {
-    getFromDirectory(Paths.get(contentRoot, "index.html").toAbsolutePath.toString)
+  } ~ path("_stats") {
+    statRoute
   } ~
+    path("" ~ PathEnd) {
+      getFromDirectory(Paths.get(contentRoot, "index.html").toAbsolutePath.toString)
+    } ~
     pathPrefix("") {
       getFromDirectory(contentRoot)
     }

--- a/server/src/main/scala/com/github/jpringle/royale/server/stats/OutgoingMessageMonitor.scala
+++ b/server/src/main/scala/com/github/jpringle/royale/server/stats/OutgoingMessageMonitor.scala
@@ -1,0 +1,68 @@
+package com.github.jpringle.royale.server.stats
+
+import akka.actor.{Actor, ActorLogging, Props}
+import com.codahale.metrics.Meter
+import com.github.jpringle.royale.common.SnakeProto.ServerEvent
+
+import scala.collection.mutable
+import com.github.jpringle.royale.common.SnakeProto.ServerEvent.{EventCase => EC}
+import com.google.protobuf.GeneratedMessageV3
+
+/**
+  * Track outgoing messages/bytes by message case
+  */
+class OutgoingMessageMonitor extends Actor with ActorLogging {
+  private val messagesOut: mutable.Map[EC, Meter] = mutable.Map.empty
+  private val bytesOut: mutable.Map[EC, Meter] = mutable.Map.empty
+
+  /**
+    * Accept a single message and record its category and size.
+    *
+    * This does mean we encode each message twice, but since the volume is so low it's not
+    * really a concern.
+    *
+    * @param key  event case
+    * @param elem any proto message
+    */
+  private def accept(key: EC, elem: GeneratedMessageV3): Unit = {
+    messagesOut.get(key) match {
+      case None => messagesOut(key) = new Meter
+      case _ =>
+    }
+    bytesOut.get(key) match {
+      case None => bytesOut(key) = new Meter
+      case _ =>
+    }
+    messagesOut(key).mark()
+    bytesOut(key).mark(elem.toByteArray.length)
+  }
+
+  /**
+    * Take a snapshot of the current outgoing message stats
+    *
+    * @return
+    */
+  private def getCurrentStats: OutgoingMessageStats = {
+    val mOut = messagesOut.map { case (ec, m) => (ec.toString, new StatSnapshot(m)) }.toMap
+    val bOut = bytesOut.map { case (ec, m) => (ec.toString, new StatSnapshot(m)) }.toMap
+    OutgoingMessageStats(mOut, bOut)
+  }
+
+  private def handleServerEvent(event: ServerEvent): Unit = event.getEventCase match {
+    case EC.GAME_STATE =>
+      accept(EC.GAME_STATE, event.getGameState)
+    case EC.JOIN_RESPONSE =>
+      accept(EC.JOIN_RESPONSE, event.getJoinResponse)
+    case _ =>
+  }
+
+  override def receive: Receive = {
+    case OutgoingMessageStatRequest => context.sender ! getCurrentStats
+    case e: ServerEvent => handleServerEvent(e)
+    case _ =>
+  }
+}
+
+object OutgoingMessageMonitor {
+  def props: Props = Props(new OutgoingMessageMonitor)
+}

--- a/server/src/main/scala/com/github/jpringle/royale/server/stats/StatJsonSupport.scala
+++ b/server/src/main/scala/com/github/jpringle/royale/server/stats/StatJsonSupport.scala
@@ -1,0 +1,27 @@
+package com.github.jpringle.royale.server.stats
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import com.codahale.metrics.Meter
+import spray.json.{DefaultJsonProtocol, PrettyPrinter}
+
+case class StatSnapshot(count: Long, rate1m: Double, rate5m: Double, rate15m: Double, rateMean: Double) {
+  def this(m: Meter) = this(
+    count = m.getCount,
+    rate1m = m.getOneMinuteRate,
+    rate5m = m.getFiveMinuteRate,
+    rate15m = m.getFifteenMinuteRate,
+    rateMean = m.getMeanRate
+  )
+}
+
+case class OutgoingMessageStats(messagesOut: Map[String, StatSnapshot], bytesOut: Map[String, StatSnapshot])
+
+trait StatRequest
+
+case object OutgoingMessageStatRequest extends StatRequest
+
+trait StatJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+  implicit val printer = PrettyPrinter
+  implicit val statSnapshotFormat = jsonFormat5(StatSnapshot)
+  implicit val outgoingMessageStatsFormat = jsonFormat2(OutgoingMessageStats)
+}


### PR DESCRIPTION
we'll also want to track how many connections are open, when they were
created, how many messages they're sending, etc. I'll get to it at some
point

![screen shot 2018-08-23 at 13 24 07](https://user-images.githubusercontent.com/3182178/44541426-e41bb280-a6d7-11e8-8637-0f980cdd4dbd.png)
